### PR TITLE
Removed all changes to the formats

### DIFF
--- a/draft-rswg-rfc7990-updates.mkd
+++ b/draft-rswg-rfc7990-updates.mkd
@@ -6,7 +6,7 @@ docname: draft-rswg-rfc7990-updates-pre07
 stand_alone: true
 v: 3
 obsoletes: 7990
-updates: 7995, 8153, 9280
+updates: 9280
 
 ipr: trust200902
 kw: Internet-Draft
@@ -28,17 +28,12 @@ author:
 normative:
   RFC7990:
   RFC7991:
-  RFC7992:
-  RFC7993:
-  RFC7994:
-  RFC7995:
   RFC7996:
   RFC7997:
 
 informative:
   RFC20:
   RFC6949:
-  RFC8153:
   RFC8650:
   RFC9280:
 
@@ -48,7 +43,6 @@ In order to improve the readability of RFCs while supporting their archivability
 This document is the framework that provides the problem statement, lays out a road map of the documents that capture the specific requirements, and describes how RFCs are published.
 
 This document obsoletes RFC 7990 and makes many significant changes to that document.
-It updates RFCs 7995 and 8153 by changing the requirement from using the PDF/A-3 standard to using the PDF/A standard and by dropping the requirement that the XML be embedded in the PDF publication version.
 It also updates the stability policy in RFC 9280.
 
 This draft is part of the RFC Series Working Group (RSWG); see <https://datatracker.ietf.org/edwg/rswg/documents/>.
@@ -109,11 +103,6 @@ Other terminology changes made by this document are the following:
 - It changes the name of the body that publishes RFCs from "RFC Editor" to "RFC Production Center (RPC)".
 
 Historical text from {{RFC7990}} such as Section 2 ("Problem Statement"), Section 4 ("Overview of the Decision-Making Process"), and Section 10 ("Transition Plan") are not copied to this document.
-
-## Changes to RFCs 7995 and 8153 {#changes-to-7995-and-8153}
-
-This document updates {{RFC7995}} and {{RFC8153}} by changing the requirement from using the PDF/A-3 standard to using the PDF/A standard,
-and by dropping the requirement that the XML be embedded in the PDF publication version.
 
 ## Changes to RFC 9280 {#changes-to-9280}
 
@@ -189,41 +178,6 @@ In deciding whether to update the publication versions of an RFC, the RPC will t
 XML format errors and better design choices have been discovered by the community since the first RFCs were published using the RFCXML format.
 When the XML in a definitive version changes, the publication versions may change, even if this might not result in observable differences.
 Similarly, as production tools change, publication versions may be regenerated to ensure a consistent presentation.
-
-## HTML
-
-{{RFC7992}} describes the semantic HTML produced by the RPC from the XML files.
-The HTML file is rendered from the XML file; it is not derived from the plain-text publication version.
-The body of the document uses a subset of HTML.
-
-The documents include Cascading Style Sheets (CSS) for default visual presentation; the CSS can be overwritten by a local CSS file.
-The allowed CSS is described in {{RFC7993}}.
-
-JavaScript in the HTML publication version is supported.
-The JavaScript in the HTML is not permitted to change the meaning of the RFC.
-The JavaScript in the HTML may add text that provides post-publication metadata or pointers. 
-
-## PDF
-
-{{RFC7995}} describes the different standards of PDF, with a recommendation of which PDF standard should apply to RFCs.
-
-The PDF file is rendered from the XML file or from the HTML publication version; it is not derived from the plain-text publication version.
-
-The PDF publication version conforms to the PDF standard.
-The RPC can decide which PDF standard will be supported after consultation with the community.
-
-This document updates {{RFC7995}} and {{RFC8153}} by changing the requirement from using the PDF/A-3 standard to instead using the PDF/A standard
-and by dropping the requirement that the XML be embedded in the PDF publication version.
-Other parts of {{RFC8153}}, particularly the need to archive metadata about RFCs, are not changed.
-
-The PDF looks more like the HTML publication version than the plain-text publication version.
-The PDF includes a rich set of tags and metadata within the document.
-
-## Plain Text
-
-{{RFC7994}} describes the details of the plain-text format.
-In particular, it focuses on what changed from the earlier plain-text format for publishing RFCs.
-
 
 # Archived Documents
 


### PR DESCRIPTION
The RSWG seems to want to give the RPC more say over the day-to-day management of the publication formats as long as they ask the community. This PR would remove anything about the formats themselves. The companion document https://github.com/paulehoffman/pub-format-updates would hold all the known publication format changes.